### PR TITLE
Added Data.List.Empty as an export to Music.Standard.Prelude

### DIFF
--- a/src/Music/Prelude/Standard.hs
+++ b/src/Music/Prelude/Standard.hs
@@ -30,6 +30,9 @@ module Music.Prelude.Standard
     Asp1a,
     defaultMain,
 
+    -- * Data NonEmpty is needed for voicings 
+    NonEmpty(..),
+
     -- * Lens re-exports
     set,
     over,
@@ -60,6 +63,7 @@ import qualified Music.Score.Part
 import qualified Options.Applicative as O
 import qualified System.Environment
 import qualified Text.Pretty
+import Data.List.NonEmpty (NonEmpty(..))
 
 type StandardNote = Asp1
 


### PR DESCRIPTION
Voiced requires a NonEmpty in order to be constructed, but NonEmpty is not part of the prelude. This pull request hopefully should fix that problem.

As an example of why it's needed:
```haskell
Voiced (chord c majorTriad) ((-1) :| [1, 0, 2, 4])
```
