### PR TITLE
Fix regression causing signatures not to be rendered

### DIFF
--- a/src/Music/Score/Meta.hs
+++ b/src/Music/Score/Meta.hs
@@ -5,7 +5,7 @@ module Music.Score.Meta
   ( module Music.Time.Meta,
 
     -- * Meta-events
-    addMetaNote,
+    addMetaEvent,
     fromMetaReactive,
     metaAtStart,
     withMeta,
@@ -19,8 +19,8 @@ import Music.Score.Internal.Util (composed)
 import Music.Time
 import Music.Time.Meta
 
-addMetaNote :: forall a b. (AttributeClass a, HasMeta b) => Event a -> b -> b
-addMetaNote x = applyMeta $ wrapTMeta $ noteToReactive x
+addMetaEvent :: forall a b. (AttributeClass a, HasMeta b) => Event a -> b -> b
+addMetaEvent x = applyMeta $ wrapTMeta $ noteToReactive x
 
 fromMetaReactive :: forall b. AttributeClass b => Meta -> Reactive b
 fromMetaReactive = fromMaybe mempty . unwrapMeta

--- a/src/Music/Score/Meta/Annotations.hs
+++ b/src/Music/Score/Meta/Annotations.hs
@@ -58,7 +58,7 @@ annotate str x = case _era x of
 
 -- | Annotate a part of the score.
 annotateSpan :: Span -> String -> Score a -> Score a
-annotateSpan span str x = addMetaNote (transform span $ return $ Annotation [str]) x
+annotateSpan span str x = addMetaEvent (transform span $ return $ Annotation [str]) x
 
 -- | Show all annotations in the score.
 showAnnotations :: (HasParts' a, Ord (GetPart a), HasText a) => Score a -> Score a

--- a/src/Music/Score/Meta/Attribution.hs
+++ b/src/Music/Score/Meta/Attribution.hs
@@ -106,7 +106,7 @@ attribute a x = case _era x of
 
 -- | Set the given attribution in the given part of a score.
 attributeDuring :: (HasMeta a) => Span -> Attribution -> a -> a
-attributeDuring s a = addMetaNote (view event (s, a))
+attributeDuring s a = addMetaEvent (view event (s, a))
 
 -- | Set composer of the given score.
 composer :: (HasMeta a, HasPosition a) => String -> a -> a

--- a/src/Music/Score/Meta/Barline.hs
+++ b/src/Music/Score/Meta/Barline.hs
@@ -64,4 +64,4 @@ barline c x = case _era x of
 
 -- | Add a barline to the given score.
 barlineDuring :: HasMeta a => Span -> Barline -> a -> a
-barlineDuring s c = addMetaNote $ view event (s, Just $ Last c)
+barlineDuring s c = addMetaEvent $ view event (s, Just $ Last c)

--- a/src/Music/Score/Meta/Clef.hs
+++ b/src/Music/Score/Meta/Clef.hs
@@ -69,4 +69,4 @@ clef c x = case _era x of
 
 -- | Set clef of the given part of a score.
 clefDuring :: HasMeta a => Span -> Clef -> a -> a
-clefDuring s c = addMetaNote $ view event (s, Just $ Last c)
+clefDuring s c = addMetaEvent $ view event (s, Just $ Last c)

--- a/src/Music/Score/Meta/Fermata.hs
+++ b/src/Music/Score/Meta/Fermata.hs
@@ -62,4 +62,4 @@ fermata c x = case _era x of
 
 -- | Add a fermata to the given score.
 fermataAt :: HasMeta a => Time -> Fermata -> a -> a
-fermataAt s c = addMetaNote $ view event (s <-> s, Option $ Just $ Last c)
+fermataAt s c = addMetaNote $ view event (s <-> s, Just $ Last c)

--- a/src/Music/Score/Meta/Fermata.hs
+++ b/src/Music/Score/Meta/Fermata.hs
@@ -35,7 +35,6 @@ import qualified Data.List as List
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
-import Data.Semigroup
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.String
@@ -49,6 +48,7 @@ import Music.Score.Part
 import Music.Score.Pitch
 import Music.Time
 import Music.Time.Reactive
+import Data.Monoid
 
 -- | Represents a fermata.
 data Fermata = StandardFermata | LongFermata | VeryLongFermata
@@ -62,4 +62,4 @@ fermata c x = case _era x of
 
 -- | Add a fermata to the given score.
 fermataAt :: HasMeta a => Time -> Fermata -> a -> a
-fermataAt s c = addMetaNote $ view event (s <-> s, Just $ Last c)
+fermataAt s c = addMetaEvent $ view event (s <-> s, Data.Monoid.Last $ Just c)

--- a/src/Music/Score/Meta/Key.hs
+++ b/src/Music/Score/Meta/Key.hs
@@ -100,4 +100,4 @@ keySignature c x = case _era x of
 
 -- | Set the key signature of the given part of a score.
 keySignatureDuring :: HasMeta a => Span -> KeySignature -> a -> a
-keySignatureDuring s c = addMetaNote $ view event (s, c)
+keySignatureDuring s c = addMetaEvent $ view event (s, c)

--- a/src/Music/Score/Meta/RehearsalMark.hs
+++ b/src/Music/Score/Meta/RehearsalMark.hs
@@ -72,4 +72,4 @@ rehearsalMark x = case _era x of
 
 -- | Place a rehearsal mark at the given time.
 rehearsalMarkAt :: HasMeta a => Time -> a -> a
-rehearsalMarkAt t = addMetaNote $ view event (t <-> t, RehearsalMark)
+rehearsalMarkAt t = addMetaEvent $ view event (t <-> t, RehearsalMark)

--- a/src/Music/Score/Meta/Tempo.hs
+++ b/src/Music/Score/Meta/Tempo.hs
@@ -153,7 +153,7 @@ tempo c x = case _era x of
 
 -- | Set the tempo of the given part of a score.
 tempoDuring :: HasMeta a => Span -> Tempo -> a -> a
-tempoDuring s c = addMetaNote $ view event (s, c)
+tempoDuring s c = addMetaEvent $ view event (s, c)
 
 {-
         inSpan' (view onsetAndOffset -> (t,u)) x = t <= x && x < u

--- a/src/Music/Score/Meta/Time.hs
+++ b/src/Music/Score/Meta/Time.hs
@@ -154,7 +154,7 @@ timeSignature c x = case _era x of
 
 -- | Set the time signature of the given part of a score.
 timeSignatureDuring :: HasMeta a => Span -> TimeSignature -> a -> a
-timeSignatureDuring s c = addMetaNote $ view event (s, optionLast c)
+timeSignatureDuring s c = addMetaEvent $ view event (s, Just $ Last c)
 
 -- | Time signature typically used for the given duration.
 --
@@ -201,10 +201,6 @@ isPowerOfTwo 0 = True
 isPowerOfTwo 1 = False
 isPowerOfTwo n = (n .&. (n -1)) == 0
 {-# INLINE isPowerOfTwo #-}
-
--- TODO consolidate
-optionLast :: a -> Maybe (Last a)
-optionLast = Just . Last
 
 mapNums :: ([Integer] -> [Integer]) -> TimeSignature -> TimeSignature
 mapDenom :: (Integer -> Integer) -> TimeSignature -> TimeSignature

--- a/src/Music/Score/Meta/Time.hs
+++ b/src/Music/Score/Meta/Time.hs
@@ -203,8 +203,8 @@ isPowerOfTwo n = (n .&. (n -1)) == 0
 {-# INLINE isPowerOfTwo #-}
 
 -- TODO consolidate
-optionLast :: a -> Option (Last a)
-optionLast = Option . Just . Last
+optionLast :: a -> Maybe (Last a)
+optionLast = Just . Last
 
 mapNums :: ([Integer] -> [Integer]) -> TimeSignature -> TimeSignature
 mapDenom :: (Integer -> Integer) -> TimeSignature -> TimeSignature

--- a/src/Music/Score/Meta/Title.hs
+++ b/src/Music/Score/Meta/Title.hs
@@ -74,11 +74,11 @@ import Music.Time.Reactive
 -- >
 -- > subtitle "Atto secundo"
 -- > ...
-newtype Title = Title (Int -> Option (Last String))
+newtype Title = Title (Int -> Maybe (Last String))
   deriving (Typeable, Monoid, Semigroup)
 
 instance IsString Title where
-  fromString x = Title $ \n -> if n == 0 then Option (Just (Last x)) else Option Nothing
+  fromString x = Title $ \n -> if n == 0 then Just (Last x) else Nothing
 
 instance Show Title where
   show = List.intercalate " " . getTitle
@@ -95,7 +95,7 @@ getTitle t = untilFail . fmap (getTitleAt t) $ [0 ..]
 
 -- | Extract the title of the given level. Semantic function.
 getTitleAt :: Title -> Int -> Maybe String
-getTitleAt (Title t) n = fmap getLast . getOption . t $ n
+getTitleAt (Title t) = fmap getLast . t 
 
 -- | Set title of the given score.
 title :: (HasMeta a, HasPosition a) => Title -> a -> a
@@ -105,7 +105,7 @@ title t x = case _era x of
 
 -- | Set title of the given part of a score.
 titleDuring :: HasMeta a => Span -> Title -> a -> a
-titleDuring s t = addMetaNote $ view event (s, t)
+titleDuring s t = addMetaEvent $ view event (s, t)
 
 -- | Set subtitle of the given score.
 subtitle :: (HasMeta a, HasPosition a) => Title -> a -> a
@@ -115,7 +115,7 @@ subtitle t x = case _era x of
 
 -- | Set subtitle of the given part of a score.
 subtitleDuring :: HasMeta a => Span -> Title -> a -> a
-subtitleDuring s t = addMetaNote $ view event (s, denoteTitle t)
+subtitleDuring s t = addMetaEvent $ view event (s, denoteTitle t)
 
 -- | Set subsubtitle of the given score.
 subsubtitle :: (HasMeta a, HasPosition a) => Title -> a -> a
@@ -125,4 +125,4 @@ subsubtitle t x = case _era x of
 
 -- | Set subsubtitle of the given part of a score.
 subsubtitleDuring :: HasMeta a => Span -> Title -> a -> a
-subsubtitleDuring s t = addMetaNote $ view event (s, denoteTitle (denoteTitle t))
+subsubtitleDuring s t = addMetaEvent $ view event (s, denoteTitle (denoteTitle t))


### PR DESCRIPTION
This fixes the regression. As far as I can tell fermata has never worked because there doesn't seem to be any code on the Lilypond side of things that generates a fermata.

In addition while looking at ```Meta.hs``` I found myself wondering if the ```Reactive``` should be replaced by a ```Behavior```. Currently fermatas are constructed using a duration of `0`, which on my understanding in a discrete set of events will be ignored. Using Behavior would solve that problem, though it's possible it would introduce new problems. An easy modification.

EDIT by @hanshoglund : This resolves the time signature aspect of #59