### PR TITLE
README: Recommend ghcup on all platforms + Dependency upgrade language

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ cabal run music-suite-test-xml-parser
 Music Suite makes heavy use of [doctests](https://en.wikipedia.org/wiki/Doctest). To run all doctests, type:
 
 ```
-$ cabal build music-suite && doctests
+$ cabal build music-suite && cabal exec doctester --package music-suite
 ```
 
 or (Nix only):


### PR DESCRIPTION
`ghcup` is now supported in Windows. This PR removes the Windows-specific install instructions in favor of recommending either Nix or ghcup for all platforms.

The PR also improves the language on dependency upgrades.