### PR TITLE
Run doctests of Music.Score.Meta in CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -72,6 +72,7 @@ pkgs.stdenv.mkDerivation {
         #  cabal exec doctester --package music-suite -- src/Music/Score/Export && \
         cabal exec doctester --package music-suite -- src/Music/Score/Import && \
         cabal exec doctester --package music-suite -- src/Music/Score/Meta && \
+        cabal exec doctester --package music-suite -- src/Music/Score/Meta.hs && \
         cabal exec doctester --package music-suite -- src/Music/Time && \
         true;
     }


### PR DESCRIPTION
We whitelist modules to doctest in CI, as not all of them pass ATM. See also #84